### PR TITLE
Bugfix for Third-age components

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -38,7 +38,7 @@ function readChatbox() {
   }
 
   var comps = chat.match(
-    /\d+ x \w+( \w+)?[^\d+:]|You receive \d+ \w+( \w+)?[^\d+:]/g
+    /\d+ x [\w-]+( \w+)?[^\d+:]|You receive \d+ [\w-]+( \w+)?[^\d+:]/g
   );
   if (comps != null && comps.length > -1) actions++;
   for (var x in comps) {


### PR DESCRIPTION
The regex didn't account for the '-' in Third-age causing it to throw an "Invalid component.  Ignoring." error.